### PR TITLE
StaticConstPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ UIButton *settingsButton;
 UIButton *setBut;
 ```
 
-A two or three letter prefix (e.g., `NST`) should always be used for class names and constants. Constants should be camel-case with all words capitalized and prefixed by the related class name for clarity. A two letter prefix (e.g., `NS`) is [reserved for use by Apple](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/DefiningClasses/DefiningClasses.html#//apple_ref/doc/uid/TP40011210-CH3-SW12).
+A two or three letter prefix (e.g., `NST`) should always be used for class names and constants (except static and local constants for internal use). Constants should be camel-case with all words capitalized and prefixed by the related class name for clarity. A two letter prefix (e.g., `NS`) is [reserved for use by Apple](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/DefiningClasses/DefiningClasses.html#//apple_ref/doc/uid/TP40011210-CH3-SW12).
 
 **Preferred:**
 


### PR DESCRIPTION
Static constant will not interfere with other constants in application, so it can be safely used without any prefixes.
